### PR TITLE
feat: normalize token parameters

### DIFF
--- a/src/backend/tools.ts
+++ b/src/backend/tools.ts
@@ -1,8 +1,8 @@
-import { QETool } from "./client";
+import { AITool } from "./client";
 import { MCPManager, MCPTool } from "../mcp/client";
 import { loadMCPConfig } from "../mcp/config";
 
-const BASE_QE_TOOLS: QETool[] = [
+const BASE_QE_TOOLS: AITool[] = [
   {
     type: "function",
     function: {
@@ -244,7 +244,7 @@ const BASE_QE_TOOLS: QETool[] = [
 ];
 
 // Morph Fast Apply tool (conditional)
-const MORPH_EDIT_TOOL: QETool = {
+const MORPH_EDIT_TOOL: AITool = {
   type: "function",
   function: {
     name: "edit_file",
@@ -271,7 +271,7 @@ const MORPH_EDIT_TOOL: QETool = {
 };
 
 // Function to build tools array conditionally
-function buildQETools(): QETool[] {
+function buildQETools(): AITool[] {
   const tools = [...BASE_QE_TOOLS];
   
   // Add Morph Fast Apply tool if API key is available
@@ -283,7 +283,7 @@ function buildQETools(): QETool[] {
 }
 
 // Export dynamic tools array
-export const QUIETENABLE_TOOLS: QETool[] = buildQETools();
+export const QUIETENABLE_TOOLS: AITool[] = buildQETools();
 
 // Global MCP manager instance
 let mcpManager: MCPManager | null = null;
@@ -339,7 +339,7 @@ export async function initializeMCPServers(): Promise<void> {
   }
 }
 
-export function convertMCPToolToQETool(mcpTool: MCPTool): QETool {
+export function convertMCPToolToQETool(mcpTool: MCPTool): AITool {
   return {
     type: "function",
     function: {
@@ -354,7 +354,7 @@ export function convertMCPToolToQETool(mcpTool: MCPTool): QETool {
   };
 }
 
-export function addMCPToolsToQETools(baseTools: QETool[]): QETool[] {
+export function addMCPToolsToQETools(baseTools: AITool[]): AITool[] {
   if (!mcpManager) {
     return baseTools;
   }
@@ -365,7 +365,7 @@ export function addMCPToolsToQETools(baseTools: QETool[]): QETool[] {
   return [...baseTools, ...qeMCPTools];
 }
 
-export async function getAllQETools(): Promise<QETool[]> {
+export async function getAllQETools(): Promise<AITool[]> {
   const manager = getMCPManager();
   // Try to initialize servers if not already done, but don't block
   manager.ensureServersInitialized().catch(() => {

--- a/src/utils/normalize-token-param.ts
+++ b/src/utils/normalize-token-param.ts
@@ -1,0 +1,22 @@
+export type Provider = 'openai' | 'grok' | 'xai';
+
+interface TokenPayload {
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  [key: string]: any;
+}
+
+export function normalizeTokenParam<T extends TokenPayload>(payload: T, provider: Provider): T {
+  if (provider === 'openai') {
+    if (payload.max_tokens !== undefined && payload.max_completion_tokens === undefined) {
+      payload.max_completion_tokens = payload.max_tokens;
+      delete payload.max_tokens;
+    }
+  } else {
+    if (payload.max_completion_tokens !== undefined && payload.max_tokens === undefined) {
+      payload.max_tokens = payload.max_completion_tokens;
+      delete payload.max_completion_tokens;
+    }
+  }
+  return payload;
+}


### PR DESCRIPTION
## Summary
- add utility to swap max_tokens vs max_completion_tokens based on provider
- refactor chat clients to use normalized token parameter
- clean up backend tool typings to use AITool consistently

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b16ed9610083249c523c0bd12693b2